### PR TITLE
Add BuildMod for Minecraft 1.21

### DIFF
--- a/buildmod/README.md
+++ b/buildmod/README.md
@@ -1,0 +1,9 @@
+# BuildMod
+
+A simple Minecraft 1.21 building mod using Fabric. It adds a `/buildcube` command
+that creates a 5x5x5 brick cube around the player.
+
+## Usage
+
+Install Fabric for Minecraft 1.21 and drop the compiled mod JAR into your mods
+folder. In game, run `/buildcube` to generate the structure.

--- a/buildmod/build.gradle
+++ b/buildmod/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'fabric-loom' version '1.1.+'
+    id 'maven-publish'
+}
+
+sourceCompatibility = JavaVersion.VERSION_17
+
+targetCompatibility = JavaVersion.VERSION_17
+
+archivesBaseName = 'buildmod'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    minecraft 'com.mojang:minecraft:1.21'
+    mappings 'net.fabricmc:yarn:1.21+build.1'
+    modImplementation 'net.fabricmc:fabric-loader:0.14.22'
+    modImplementation 'net.fabricmc.fabric-api:fabric-api:0.89.0+1.21'
+}
+
+processResources {
+    inputs.property "version", project.version
+
+    filesMatching("fabric.mod.json") {
+        expand "version": project.version
+    }
+}

--- a/buildmod/settings.gradle
+++ b/buildmod/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'buildmod'

--- a/buildmod/src/main/java/com/example/buildmod/BuildMod.java
+++ b/buildmod/src/main/java/com/example/buildmod/BuildMod.java
@@ -1,0 +1,36 @@
+package com.example.buildmod;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.block.Blocks;
+
+public class BuildMod implements ModInitializer {
+    public static final String MOD_ID = "buildmod";
+
+    @Override
+    public void onInitialize() {
+        CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
+            dispatcher.register(CommandManager.literal("buildcube")
+                .executes(context -> {
+                    ServerCommandSource source = context.getSource();
+                    World world = source.getWorld();
+                    BlockPos pos = new BlockPos(source.getPosition());
+                    for (int x = 0; x < 5; x++) {
+                        for (int y = 0; y < 5; y++) {
+                            for (int z = 0; z < 5; z++) {
+                                BlockPos newPos = pos.add(x, y, z);
+                                world.setBlockState(newPos, Blocks.BRICKS.getDefaultState());
+                            }
+                        }
+                    }
+                    source.sendFeedback(() -> Text.literal("Cube built!"), false);
+                    return 1;
+                }));
+        });
+    }
+}

--- a/buildmod/src/main/resources/fabric.mod.json
+++ b/buildmod/src/main/resources/fabric.mod.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "id": "buildmod",
+  "version": "1.0.0",
+  "name": "BuildMod",
+  "description": "A simple building mod for Minecraft 1.21",
+  "authors": ["Codex"],
+  "contact": {
+    "homepage": "https://example.com",
+    "sources": "https://example.com"
+  },
+  "license": "MIT",
+  "environment": "*",
+  "entrypoints": {
+    "main": ["com.example.buildmod.BuildMod"]
+  },
+  "depends": {
+    "fabricloader": ">=0.14.0",
+    "minecraft": "1.21*",
+    "fabric": "*"
+  }
+}


### PR DESCRIPTION
## Summary
- add BuildMod skeleton using Fabric
- provide a `/buildcube` command that builds a 5x5x5 brick cube
- include Fabric build config and README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841a315b05c8323a5d9a7f572a2702f